### PR TITLE
Amend testOptions for junit compatibility.

### DIFF
--- a/project/DefaultBuildSettings.scala
+++ b/project/DefaultBuildSettings.scala
@@ -52,8 +52,9 @@ object DefaultBuildSettings {
   }
 
   def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
-    val testResultDir = "target/" + directory
-    testOptions in conf += Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
+    val testResultDir = s"target/$directory"
+    testOptions in conf += Tests.Argument(TestFrameworks.ScalaTest, "-o", "-u", testResultDir, "-h", s"$testResultDir/html-report")
+    testOptions in conf += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q")
   }
 
   private def gitStampInfo() = {

--- a/project/PluginBuild.scala
+++ b/project/PluginBuild.scala
@@ -59,7 +59,7 @@ object BuildDescriptionSettings {
       <scm>
         <connection>scm:git@github.com:hmrc/sbt-settings.git</connection>
         <developerConnection>scm:git@github.com:hmrc/sbt-settings.git</developerConnection>
-        <url>git@github.com:hmrc/sbt-utils.git</url>
+        <url>git@github.com:hmrc/sbt-settings.git</url>
       </scm>
       <developers>
         <developer>

--- a/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
@@ -61,8 +61,9 @@ object DefaultBuildSettings {
   }
 
   def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
-    val testResultDir = "target/" + directory
-    testOptions in conf += Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
+    val testResultDir = s"target/$directory"
+    testOptions in conf += Tests.Argument(TestFrameworks.ScalaTest, "-o", "-u", testResultDir, "-h", s"$testResultDir/html-report")
+    testOptions in conf += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q")
   }
 
   private def gitStampInfo() = {


### PR DESCRIPTION
junit breaks with the arguments specified globally. These have been amended to be ScalaTest scoped with new junit specific arguments added.
sbt-settings url corrected in pomExtra.

NB: This change is a precursor to an update to sbt-auto-build