### PR TITLE
Refactor out test argument from default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ sbt-settings
 
 SBT plugin providing standard functions and configurations
 
+## Note ##
+
+Versions >3.3.0 no longer add the JUnit style test reporting in Test scope by default. If this is required consumers will need to add this (see [DefaultBuildSettings#addTestReportOption](https://github.com/hmrc/sbt-settings/blob/master/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala#L63))
+
 ## License ##
  
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/project/DefaultBuildSettings.scala
+++ b/project/DefaultBuildSettings.scala
@@ -26,7 +26,7 @@ object DefaultBuildSettings {
     targetJvm := "jvm-1.8"
 
     Seq(
-      scalaVersion := "2.11.6",
+      scalaVersion := "2.11.8",
       scalacOptions ++= Seq(
         "-unchecked",
         "-deprecation",
@@ -51,7 +51,7 @@ object DefaultBuildSettings {
     if (addScalaTestReports) ds ++ addTestReportOption(Test) else ds
   }
 
-  def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
+  private def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
     val testResultDir = "target/" + directory
     testOptions in conf += Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.12

--- a/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
@@ -31,7 +31,7 @@ object DefaultBuildSettings {
     targetJvm := "jvm-1.8"
 
     Seq(
-      scalaVersion := "2.11.6",
+      scalaVersion := "2.11.8",
       scalacOptions ++= Seq(
         "-Xlint",
         "-target:" + targetJvm.value,
@@ -48,21 +48,20 @@ object DefaultBuildSettings {
     )
   }
 
-  def defaultSettings(addScalaTestReports: Boolean = true) : Seq[Setting[_]] = {
-    val ds = Seq(
+  def defaultSettings() : Seq[Setting[_]] = {
+    Seq(
       organization := "uk.gov.hmrc",
       initialCommands in console := "import " + organization + "._",
       parallelExecution in Test := false,
       fork in Test := false,
       isSnapshot := version.value.matches("([\\w]+\\-SNAPSHOT)|([\\.\\w]+)\\-([\\d]+)\\-([\\w]+)")
     ) ++ gitStampInfo
-
-    if (addScalaTestReports) ds ++ addTestReportOption(Test) else ds
   }
 
-  def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
+
+  def addTestReportOption(directory: String = "test-reports") = {
     val testResultDir = "target/" + directory
-    testOptions in conf += Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
+    Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
   }
 
   private def gitStampInfo() = {

--- a/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
@@ -59,9 +59,9 @@ object DefaultBuildSettings {
   }
 
 
-  def addTestReportOption(directory: String = "test-reports") = {
+  def addTestReportOption(conf: Configuration, directory: String = "test-reports") = {
     val testResultDir = "target/" + directory
-    Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
+    testOptions in conf += Tests.Argument("-o", "-u", testResultDir, "-h", testResultDir + "/html-report")
   }
 
   private def gitStampInfo() = {


### PR DESCRIPTION
The test report argument is applicable to most but not all builds and therefore I have refactored the test argument out of the function defaultSettings(). The test argument defined in the function addTestReportOption() would need to be added to specific builds where applicable.