### PR TITLE
Pass forked javaOptions to test groups in ForkedJvmPerTestSettings

### DIFF
--- a/src/main/scala-sbt-0.13/uk/gov/hmrc/ForkedJvmPerTestSettings.scala
+++ b/src/main/scala-sbt-0.13/uk/gov/hmrc/ForkedJvmPerTestSettings.scala
@@ -21,9 +21,9 @@ import sbt._
 import scala.language.postfixOps
 
 object ForkedJvmPerTestSettings {
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = tests map { test =>
+  def oneForkedJvmPerTest(tests: Seq[TestDefinition], forkJvmOptions: Seq[String] = Seq.empty): Seq[Group] = tests map { test =>
     Group(test.name, Seq(test), SubProcess(ForkOptions(
-      runJVMOptions = Seq("-Dtest.name=" + test.name))
-    ))
+      runJVMOptions = forkJvmOptions ++ Seq("-Dtest.name=" + test.name)
+    )))
   }
 }

--- a/src/main/scala-sbt-1.0/uk/gov/hmrc/ForkedJvmPerTestSettings.scala
+++ b/src/main/scala-sbt-1.0/uk/gov/hmrc/ForkedJvmPerTestSettings.scala
@@ -21,9 +21,9 @@ import sbt._
 import scala.language.postfixOps
 
 object ForkedJvmPerTestSettings {
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = tests map { test =>
+  def oneForkedJvmPerTest(tests: Seq[TestDefinition], forkJvmOptions: Seq[String] = Seq.empty): Seq[Group] = tests map { test =>
     Group(test.name, Seq(test), SubProcess(
-        ForkOptions().withRunJVMOptions(Vector("-Dtest.name=" + test.name))
+        ForkOptions().withRunJVMOptions(forkJvmOptions.toVector ++ Vector("-Dtest.name=" + test.name))
     ))
   }
 }

--- a/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
@@ -74,7 +74,10 @@ object DefaultBuildSettings {
       Keys.fork in IntegrationTest := false,
       unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest)(base => Seq(base / "it")).value,
       addTestReportOption(IntegrationTest, "int-test-reports"),
-      testGrouping in IntegrationTest := ForkedJvmPerTestSettings.oneForkedJvmPerTest((definedTests in IntegrationTest).value),
+      testGrouping in IntegrationTest := ForkedJvmPerTestSettings.oneForkedJvmPerTest(
+        (definedTests in IntegrationTest).value,
+        (javaOptions in IntegrationTest).value
+      ),
       parallelExecution in IntegrationTest := false
     ) ++
     (if (enableLicenseHeaders) {


### PR DESCRIPTION
Motivating example:

```
[transits-movements-trader-at-departure] $ show IntegrationTest / fork
[info] true
[transits-movements-trader-at-departure] $ show IntegrationTest / javaOptions
[info] * -Djdk.xml.maxOccurLimit=10000
[info] * -Dconfig.resource=it.application.conf
[info] * -Dlogger.resource=it.logback.xml
[success] Total time: 0 s, completed 20-Apr-2021 12:06:25
[transits-movements-trader-at-departure] $ show IntegrationTest / testGrouping
[info] SbtArtifactoryPlugin [1.13.0] (transits-movements-trader-at-departure) - Configuring Artifactory credentials: None
[info] * Group(repositories.DepartureRepositorySpec,List(Test repositories.DepartureRepositorySpec : subclass(false, org.scalatest.Suite)),SubProcess(ForkOptions(None, None, Vector(), None, Vector(-Dtest.name=repositories.DepartureRepositorySpec), false, Map())))
[info] * Group(repositories.LockRepositorySpec,List(Test repositories.LockRepositorySpec : subclass(false, org.scalatest.Suite)),SubProcess(ForkOptions(None, None, Vector(), None, Vector(-Dtest.name=repositories.LockRepositorySpec), false, Map())))
[info] * Group(repositories.DepartureIdRepositorySpec,List(Test repositories.DepartureIdRepositorySpec : subclass(false, org.scalatest.Suite)),SubProcess(ForkOptions(None, None, Vector(), None, Vector(-Dtest.name=repositories.DepartureIdRepositorySpec), false, Map())))
[info] * Group(api.PDFRetrievalControllerISpec,List(Test api.PDFRetrievalControllerISpec : subclass(false, org.scalatest.Suite)),SubProcess(ForkOptions(None, None, Vector(), None, Vector(-Dtest.name=api.PDFRetrievalControllerISpec), false, Map())))
[success] Total time: 0 s, completed 20-Apr-2021 12:06:27
```
At present the `javaOptions` are ignored and are not passed on to the forked test groups if you are using `DefaultBuildSettings.integrationTestSettings` in your build.