### PR TITLE
Fix use of target for newer Scala 2.12

### DIFF
--- a/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
+++ b/src/main/scala/uk/gov/hmrc/DefaultBuildSettings.scala
@@ -56,7 +56,8 @@ object DefaultBuildSettings {
            else Seq.empty
           )++
           // https://www.scala-lang.org/news/2.13.9
-          (if (toLong(scalaVersion.value) < toLong("2.13.9"))
+          (if ((scalaBinaryVersion.value == "2.13") && toLong(scalaVersion.value) < toLong("2.13.9")
+            || (scalaBinaryVersion.value == "2.12") && toLong(scalaVersion.value) < toLong("2.12.17"))
              Seq("-target:" + targetJvm.value)
            else
               Seq("-release", targetJvm.value.stripPrefix("jvm-").stripPrefix("1."))


### PR DESCRIPTION
This is still required for plugins (which use Scala 2.12)